### PR TITLE
Added support for the explicit operand delimiter, "--".

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ located [here](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap1
 
 Each argument is treated as a key-value pair, regardless of whether a value is present.  The general format is as follows:
 
-```<-|--|/>argument-name<=|:| >["|']value['|"] [operand] ... [operand]```
+```<-|--|/>argument-name<=|:| >["|']value['|"] [--] [operand] ... [operand]```
 
 The key-value pair may begin with a single dash, a pair of dashes (double dash), or a forward slash.  Single and double dashes indicate the use of short
 or long names, respectively, which are covered below.  The forward slash may represent either, but does not allow for the grouping of parameterless
@@ -85,6 +85,9 @@ Values may be any alphanumeric sequence, however if a value contains a space it 
 
 Any word, or phrase enclosed in single or double quotes, will be parsed as an operand.  The official specification requires operands to appear last, however this library will
 parse them in any position.
+
+A double-hyphen ```--```, not enclosed in single or double quotes, and appearing with whitespace on either side, designates the end of the argument list and beginning of 
+the operand list.  Anything appearing after this delimiter is treated as an operand, even if it begins with a hyphen, double-hyphen or forward slash.
 
 ### Short Names
 
@@ -158,11 +161,12 @@ new | slashes are ok too
 
 ### Operands
 
-Any text in the string that doesn't match the argument-value format is considered an operand.
+Any text in the string that doesn't match the argument-value format is considered an operand.  Any text which appears after a double-hyphen ```--```, not enclosed in single or double quotes, and with spaces on either side,
+is treated as an operand regardless of whether it matches the argument-value format.
 
 #### Example
 
-```-a foo bar "hello world" -b```
+```-a foo bar "hello world" -b -- -explicit operand```
 
 Key | Value
 --- | ---
@@ -172,6 +176,8 @@ b |
 Operands
 1. bar
 2. "hello world"
+3. -explicit
+4. operand
 
 ## Parsing
 

--- a/Utility.CommandLine.Arguments.Tests/Arguments.cs
+++ b/Utility.CommandLine.Arguments.Tests/Arguments.cs
@@ -168,6 +168,24 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit operand delimiter.
+        /// </summary>
+        [Fact]
+        public void ParseStrictOperands()
+        {
+            CommandLine.Arguments test = CommandLine.Arguments.Parse("--test one two -- three -four --five /six \"seven eight\" 'nine ten'");
+
+            Assert.Equal(7, test.OperandList.Count);
+            Assert.Equal("two", test.OperandList[0]);
+            Assert.Equal("three", test.OperandList[1]);
+            Assert.Equal("-four", test.OperandList[2]);
+            Assert.Equal("--five", test.OperandList[3]);
+            Assert.Equal("/six", test.OperandList[4]);
+            Assert.Equal("\"seven eight\"", test.OperandList[5]);
+            Assert.Equal("'nine ten'", test.OperandList[6]);
+        }
+
+        /// <summary>
         ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit command line string
         ///     containing a mixture of upper and lower case arguments.
         /// </summary>

--- a/Utility.CommandLine.Arguments/Arguments.cs
+++ b/Utility.CommandLine.Arguments/Arguments.cs
@@ -142,8 +142,8 @@ namespace Utility.CommandLine
         ///     operands, and strictly operands.
         /// </summary>
         /// <remarks>
-        ///     This regEx effectively splits a string into two parts; the part before the first "--", and the part after.
-        ///     Instances of "--" not surrounded by a word boundary and those enclosed in quotes are ignored.
+        ///     This regular expression effectively splits a string into two parts; the part before the first "--", and the part
+        ///     after. Instances of "--" not surrounded by a word boundary and those enclosed in quotes are ignored.
         /// </remarks>
         private const string StrictOperandSplitRegEx = "(.*?)[^\\\"\\\']\\B-{2}\\B[^\\\"\\\'](.*)";
 
@@ -228,18 +228,18 @@ namespace Utility.CommandLine
             MatchCollection matches = Regex.Matches(commandLineString, StrictOperandSplitRegEx);
 
             // if there is a match, the string contains the strict operand delimiter. parse the first and second matches accordingly.
-            if (matches.Count > 0)
+            if (matches.Count > 0 && matches[0].Groups.Count >= 1)
             {
                 // the first group of the first match will contain everything in the string prior to the strict operand delimiter,
                 // so extract the argument key/value pairs and list of operands from that string.
-                argumentDictionary = GetArgumentDictionary(matches[0].Groups[0].Value);
-                operandList = GetOperandList(matches[0].Groups[0].Value);
+                argumentDictionary = GetArgumentDictionary(matches[0].Groups[1].Value);
+                operandList = GetOperandList(matches[0].Groups[1].Value);
 
                 // the first group of the second match will contain everything in the string after the strict operand delimiter, so
                 // extract the operands from that string using the strict method.
-                if (matches.Count > 1)
+                if (matches[0].Groups.Count > 1)
                 {
-                    List<string> operandListStrict = GetOperandListStrict(matches[1].Groups[0].Value);
+                    List<string> operandListStrict = GetOperandListStrict(matches[0].Groups[2].Value);
 
                     // join the operand lists.
                     operandList.AddRange(operandListStrict);

--- a/Utility.CommandLine.Arguments/Arguments.cs
+++ b/Utility.CommandLine.Arguments/Arguments.cs
@@ -137,6 +137,21 @@ namespace Utility.CommandLine
         /// </summary>
         private const string GroupRegEx = "^-[^-]+";
 
+        /// <summary>
+        ///     The regular expression with which to split the command line string explicitly among argument/value pairs and
+        ///     operands, and strictly operands.
+        /// </summary>
+        /// <remarks>
+        ///     This regEx effectively splits a string into two parts; the part before the first "--", and the part after.
+        ///     Instances of "--" not surrounded by a word boundary and those enclosed in quotes are ignored.
+        /// </remarks>
+        private const string StrictOperandSplitRegEx = "(.*?)[^\\\"\\\']\\B-{2}\\B[^\\\"\\\'](.*)";
+
+        /// <summary>
+        ///     The regular expression with which to parse strings strictly containing operands.
+        /// </summary>
+        private const string OperandRegEx = "([^ ([^'\\\"]+|\\\"[^\\\"]+\\\"|\\\'[^']+\\\')";
+
         #endregion Private Fields
 
         #region Private Constructors
@@ -206,7 +221,37 @@ namespace Utility.CommandLine
         {
             commandLineString = commandLineString.Equals(string.Empty) ? Environment.CommandLine : commandLineString;
 
-            return new Arguments(GetArgumentDictionary(commandLineString), GetOperands(commandLineString));
+            Dictionary<string, string> argumentDictionary;
+            List<string> operandList;
+
+            // use the strict operand regular expression to test for/extract the two halves of the string, if the operator is used.
+            MatchCollection matches = Regex.Matches(commandLineString, StrictOperandSplitRegEx);
+
+            // if there is a match, the string contains the strict operand delimiter. parse the first and second matches accordingly.
+            if (matches.Count > 0)
+            {
+                // the first group of the first match will contain everything in the string prior to the strict operand delimiter,
+                // so extract the argument key/value pairs and list of operands from that string.
+                argumentDictionary = GetArgumentDictionary(matches[0].Groups[0].Value);
+                operandList = GetOperandList(matches[0].Groups[0].Value);
+
+                // the first group of the second match will contain everything in the string after the strict operand delimiter, so
+                // extract the operands from that string using the strict method.
+                if (matches.Count > 1)
+                {
+                    List<string> operandListStrict = GetOperandListStrict(matches[1].Groups[0].Value);
+
+                    // join the operand lists.
+                    operandList.AddRange(operandListStrict);
+                }
+            }
+            else
+            {
+                argumentDictionary = GetArgumentDictionary(commandLineString);
+                operandList = GetOperandList(commandLineString);
+            }
+
+            return new Arguments(argumentDictionary, operandList);
         }
 
         /// <summary>
@@ -423,7 +468,7 @@ namespace Utility.CommandLine
         /// <returns>
         ///     A list containing the operands specified in the command line arguments with which the application was started.
         /// </returns>
-        private static List<string> GetOperands(string commandLineString)
+        private static List<string> GetOperandList(string commandLineString)
         {
             List<string> operands = new List<string>();
 
@@ -439,6 +484,28 @@ namespace Utility.CommandLine
                 string operand = match.Groups[3].Value;
 
                 operands.Add(TrimOuterQuotes(operand));
+            }
+
+            return operands;
+        }
+
+        /// <summary>
+        ///     Populates and returns a list containing the operands within the specified string grouped by whole words and groups
+        ///     of words contained within single or double quotes, treating strings that would otherwise be treated as argument
+        ///     keys as operands.
+        /// </summary>
+        /// <param name="operandListString">The string from which the list of operands is to be parsed.</param>
+        /// <returns>
+        ///     A list containing the operands within the specified string grouped by whole words and groups of words contained
+        ///     within single or double quotes, treating strings that would otherwise be treated as argument keys as operands.
+        /// </returns>
+        private static List<string> GetOperandListStrict(string operandListString)
+        {
+            List<string> operands = new List<string>();
+
+            foreach (Match match in Regex.Matches(operandListString, OperandRegEx))
+            {
+                operands.Add(match.Groups[0].Value);
             }
 
             return operands;

--- a/Utility.CommandLine.Arguments/Properties/AssemblyInfo.cs
+++ b/Utility.CommandLine.Arguments/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("b739dd22-4bd3-4d17-a351-33d129e9fe30")]
-[assembly: AssemblyVersion("1.1.2")]
-[assembly: AssemblyFileVersion("1.1.2")]
+[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyFileVersion("1.2.0")]


### PR DESCRIPTION
Anything after this delimiter is treated as an operand, regardless of whether it matches the argument-value format.