### PR TITLE
Add support for default values

### DIFF
--- a/examples/Example/Program.cs
+++ b/examples/Example/Program.cs
@@ -145,6 +145,7 @@ namespace Examples
         {
             String = string.Empty;
             Bool = false;
+            Help = false;
             Int = 0;
             Double = 0;
             List = new List<int>();

--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -273,9 +273,9 @@ namespace Utility.CommandLine
         ///     arguments, if present.
         /// </summary>
         /// <param name="commandLineString">The command line arguments with which the application was started.</param>
-        public static void Populate(string commandLineString = default(string))
+        public static void Populate(string commandLineString = default(string), bool clearExistingValues = false)
         {
-            Populate(new StackFrame(1).GetMethod().DeclaringType, Parse(commandLineString));
+            Populate(new StackFrame(1).GetMethod().DeclaringType, Parse(commandLineString), clearExistingValues);
         }
 
         /// <summary>
@@ -287,9 +287,9 @@ namespace Utility.CommandLine
         ///     The Type for which the static properties matching the list of command line arguments are to be populated.
         /// </param>
         /// <param name="commandLineString">The command line arguments with which the application was started.</param>
-        public static void Populate(Type type, string commandLineString = default(string))
+        public static void Populate(Type type, string commandLineString = default(string), bool clearExistingValues = false)
         {
-            Populate(type, Parse(commandLineString));
+            Populate(type, Parse(commandLineString), clearExistingValues);
         }
 
         /// <summary>
@@ -304,12 +304,15 @@ namespace Utility.CommandLine
         ///     The Arguments object containing the dictionary containing the argument-value pairs with which the destination
         ///     properties should be populated and the list of operands.
         /// </param>
-        public static void Populate(Type type, Arguments arguments)
+        public static void Populate(Type type, Arguments arguments, bool clearExistingValues = false)
         {
             // fetch any properties in the specified type marked with the ArgumentAttribute attribute and clear them
             Dictionary<string, PropertyInfo> properties = GetArgumentProperties(type);
 
-            ClearProperties(properties);
+            if (clearExistingValues)
+            {
+                ClearProperties(properties);
+            }
 
             foreach (string propertyName in properties.Keys)
             {

--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -273,7 +273,7 @@ namespace Utility.CommandLine
         ///     arguments, if present.
         /// </summary>
         /// <param name="commandLineString">The command line arguments with which the application was started.</param>
-        public static void Populate(string commandLineString = default(string), bool clearExistingValues = false)
+        public static void Populate(string commandLineString = default(string), bool clearExistingValues = true)
         {
             Populate(new StackFrame(1).GetMethod().DeclaringType, Parse(commandLineString), clearExistingValues);
         }
@@ -287,7 +287,7 @@ namespace Utility.CommandLine
         ///     The Type for which the static properties matching the list of command line arguments are to be populated.
         /// </param>
         /// <param name="commandLineString">The command line arguments with which the application was started.</param>
-        public static void Populate(Type type, string commandLineString = default(string), bool clearExistingValues = false)
+        public static void Populate(Type type, string commandLineString = default(string), bool clearExistingValues = true)
         {
             Populate(type, Parse(commandLineString), clearExistingValues);
         }
@@ -304,7 +304,7 @@ namespace Utility.CommandLine
         ///     The Arguments object containing the dictionary containing the argument-value pairs with which the destination
         ///     properties should be populated and the list of operands.
         /// </param>
-        public static void Populate(Type type, Arguments arguments, bool clearExistingValues = false)
+        public static void Populate(Type type, Arguments arguments, bool clearExistingValues = true)
         {
             // fetch any properties in the specified type marked with the ArgumentAttribute attribute and clear them
             Dictionary<string, PropertyInfo> properties = GetArgumentProperties(type);

--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -80,7 +80,7 @@ namespace Utility.CommandLine
 
     /// <summary>
     ///     Indicates that the property is to be used as a target for automatic population of values from command line arguments
-    ///     when invoking the <see cref="Arguments.Populate(string)"/> method.
+    ///     when invoking the <see cref="Arguments.Populate(string, bool)"/> method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
     public class ArgumentAttribute : Attribute
@@ -273,6 +273,7 @@ namespace Utility.CommandLine
         ///     arguments, if present.
         /// </summary>
         /// <param name="commandLineString">The command line arguments with which the application was started.</param>
+        /// <param name="clearExistingValues">Whether to clear the properties before populating them. Defaults to true.</param>
         public static void Populate(string commandLineString = default(string), bool clearExistingValues = true)
         {
             Populate(new StackFrame(1).GetMethod().DeclaringType, Parse(commandLineString), clearExistingValues);
@@ -287,6 +288,7 @@ namespace Utility.CommandLine
         ///     The Type for which the static properties matching the list of command line arguments are to be populated.
         /// </param>
         /// <param name="commandLineString">The command line arguments with which the application was started.</param>
+        /// <param name="clearExistingValues">Whether to clear the properties before populating them. Defaults to true.</param>
         public static void Populate(Type type, string commandLineString = default(string), bool clearExistingValues = true)
         {
             Populate(type, Parse(commandLineString), clearExistingValues);
@@ -304,6 +306,7 @@ namespace Utility.CommandLine
         ///     The Arguments object containing the dictionary containing the argument-value pairs with which the destination
         ///     properties should be populated and the list of operands.
         /// </param>
+        /// <param name="clearExistingValues">Whether to clear the properties before populating them. Defaults to true.</param>
         public static void Populate(Type type, Arguments arguments, bool clearExistingValues = true)
         {
             // fetch any properties in the specified type marked with the ArgumentAttribute attribute and clear them
@@ -670,7 +673,7 @@ namespace Utility.CommandLine
 
     /// <summary>
     ///     Indicates that the property is to be used as the target for automatic population of command line operands when invoking
-    ///     the <see cref="Arguments.Populate(string)"/> method.
+    ///     the <see cref="Arguments.Populate(string, bool)"/> method.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
     public class OperandsAttribute : Attribute

--- a/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
+++ b/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
@@ -662,7 +662,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string)"/> method to assure that properties are "cleared"
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string, bool)"/> method to assure that properties are "cleared"
         ///     prior to populating values.
         /// </summary>
         [Fact]

--- a/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
+++ b/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
@@ -557,6 +557,24 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string, bool)"/> method to assure that properties are not
+        ///     "cleared" when clearing is explicitly disabled.
+        /// </summary>
+        [Fact]
+        public void PopulateDisableClearing()
+        {
+            Bool = true;
+            Decimal = 3.5m;
+            Integer = 42;
+
+            CommandLine.Arguments.Populate(string.Empty, false);
+
+            Assert.True(Bool);
+            Assert.Equal(3.5m, Decimal);
+            Assert.Equal(42, Integer);
+        }
+
+        /// <summary>
         ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit command line
         ///     string and with a class containing duplicate properties.
         /// </summary>

--- a/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
+++ b/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
@@ -517,7 +517,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string)"/> method with the default values.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string, bool)"/> method with the default values.
         /// </summary>
         [Fact]
         public void Populate()
@@ -528,7 +528,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string)"/> method with an explicit command line string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string, bool)"/> method with an explicit command line string
         ///     containing both upper and lower case arguments.
         /// </summary>
         [Fact]
@@ -546,7 +546,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="CommandLine.Arguments.Populate(string)"/> method with a decimal value.
+        ///     Tests the <see cref="CommandLine.Arguments.Populate(string, bool)"/> method with a decimal value.
         /// </summary>
         [Fact]
         public void PopulateDecimal()
@@ -557,7 +557,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with an explicit command line
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit command line
         ///     string and with a class containing duplicate properties.
         /// </summary>
         [Fact]
@@ -572,7 +572,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with a Type external to the
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with a Type external to the
         ///     calling class and with an explicit string.
         /// </summary>
         [Fact]
@@ -586,7 +586,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with a string containing
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with a string containing
         ///     multiple values for an argument which is not backed by a collection.
         /// </summary>
         [Fact]
@@ -599,7 +599,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with an explicit command line
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit command line
         ///     string containing two operands.
         /// </summary>
         [Fact]
@@ -612,7 +612,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string)"/> method with an explicit command line string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string, bool)"/> method with an explicit command line string
         ///     containing multiple short names.
         /// </summary>
         [Fact]
@@ -625,7 +625,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string)"/> method with an explicit command line string.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string, bool)"/> method with an explicit command line string.
         /// </summary>
         [Fact]
         public void PopulateString()
@@ -638,7 +638,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string)"/> method with an explicit type.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string, bool)"/> method with an explicit type.
         /// </summary>
         [Fact]
         public void PopulateType()
@@ -649,7 +649,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string)"/> method with an explicit type and command
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(string, bool)"/> method with an explicit type and command
         ///     line string, where the string contains a value which does not match the type of the destination property.
         /// </summary>
         [Fact]
@@ -766,7 +766,7 @@ namespace Utility.CommandLine.Tests
         #region Public Methods
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with an explicit string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit string
         ///     containing two operands, and with a Type containing a property of type <see langword="string[]"/> marked with the
         ///     <see cref="Operands"/> attribute.
         /// </summary>
@@ -802,7 +802,7 @@ namespace Utility.CommandLine.Tests
         #region Public Methods
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with an explicit string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit string
         ///     containing multiple instances of the same argument.
         /// </summary>
         [Fact]
@@ -818,7 +818,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with an explicit string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit string
         ///     containing a single a single instance of an array-backed argument.
         /// </summary>
         [Fact]
@@ -856,7 +856,7 @@ namespace Utility.CommandLine.Tests
         #region Public Methods
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with an explicit string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit string
         ///     containing two operands, and with a Type containing a property marked with the <see cref="Operands"/> attribute but
         ///     that is not of type <see cref="T:string[]"/> or <see cref="List{T}"/>}"/&gt; .
         /// </summary>
@@ -892,7 +892,7 @@ namespace Utility.CommandLine.Tests
         #region Public Methods
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with an explicit string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit string
         ///     containing multiple instances of a list-backed argument.
         /// </summary>
         [Fact]
@@ -908,7 +908,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with an explicit string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit string
         ///     containing a single a single instance of a list-backed argument.
         /// </summary>
         [Fact]
@@ -934,7 +934,7 @@ namespace Utility.CommandLine.Tests
         #region Public Methods
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with an explicit string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit string
         ///     containing a single argument/value pair, and with a Type containing no properties.
         /// </summary>
         [Fact]
@@ -988,7 +988,7 @@ namespace Utility.CommandLine.Tests
         private static List<string> Operands { get; set; }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with an explicit string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit string
         ///     containing a single boolean followed by a single operand.
         /// </summary>
         [Fact]
@@ -1003,7 +1003,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string)"/> method with an explicit string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Populate(Type, string, bool)"/> method with an explicit string
         ///     containing a single boolean followed by two operands.
         /// </summary>
         [Fact]


### PR DESCRIPTION
Closes #37.

Using the `TestClassWithDefaultValues` class for the included test caused it to fail unless it was run by itself. Presumably, this is because of side effects from the `SetsDefaultValuesOnPopulate` test.