### PR TITLE
Support mixture of short and long argument names

### DIFF
--- a/examples/Example/Program.cs
+++ b/examples/Example/Program.cs
@@ -156,7 +156,7 @@ namespace Examples
         /// </summary>
         private static void ShowHelp()
         {
-            var helpAttributes = Arguments.GetArgumentHelp(typeof(Program));
+            var helpAttributes = Arguments.GetArgumentInfo(typeof(Program));
 
             Console.WriteLine("Short\tLong\tFunction");
             Console.WriteLine("-----\t----\t--------");

--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -669,7 +669,29 @@ namespace Utility.CommandLine
     /// <summary>
     ///     Encapsulates argument names and help text.
     /// </summary>
+    [Obsolete]
     public class ArgumentHelp
+    {
+        /// <summary>
+        ///     Gets or sets the help text for the argument.
+        /// </summary>
+        public string HelpText { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the long name of the argument.
+        /// </summary>
+        public string LongName { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the short name of the argument.
+        /// </summary>
+        public char ShortName { get; set; }
+    }
+
+    /// <summary>
+    ///     Encapsulates argument names and help text.
+    /// </summary>
+    public class ArgumentInfo
     {
         /// <summary>
         ///     Gets or sets the help text for the argument.

--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -204,7 +204,8 @@ namespace Utility.CommandLine
         {
             type = type ?? new StackFrame(1).GetMethod().DeclaringType;
 
-            return GetArgumentInfo(type).Select(i => new ArgumentHelp() {
+            return GetArgumentInfo(type).Select(i => new ArgumentHelp()
+            {
                 ShortName = i.ShortName,
                 LongName = i.LongName,
                 HelpText = i.HelpText,
@@ -245,12 +246,15 @@ namespace Utility.CommandLine
         ///     started, keyed by argument name.
         /// </summary>
         /// <param name="commandLineString">The command line arguments with which the application was started.</param>
+        /// <param name="type">The <see cref="Type"/> for which the command line string is to be parsed.</param>
         /// <returns>
         ///     The dictionary containing the arguments and values specified in the command line arguments with which the
         ///     application was started.
         /// </returns>
-        public static Arguments Parse(string commandLineString = default(string))
+        public static Arguments Parse(string commandLineString = default(string), Type type = null)
         {
+            type = type ?? new StackFrame(1).GetMethod().DeclaringType;
+
             commandLineString = commandLineString == default(string) || commandLineString == string.Empty ? Environment.CommandLine : commandLineString;
 
             Dictionary<string, object> argumentDictionary;
@@ -264,7 +268,7 @@ namespace Utility.CommandLine
             {
                 // the first group of the first match will contain everything in the string prior to the strict operand delimiter,
                 // so extract the argument key/value pairs and list of operands from that string.
-                argumentDictionary = GetArgumentDictionary(matches[0].Groups[1].Value);
+                argumentDictionary = GetArgumentDictionary(matches[0].Groups[1].Value, type);
                 operandList = GetOperandList(matches[0].Groups[1].Value);
 
                 // the first group of the second match will contain everything in the string after the strict operand delimiter, so
@@ -279,7 +283,7 @@ namespace Utility.CommandLine
             }
             else
             {
-                argumentDictionary = GetArgumentDictionary(commandLineString);
+                argumentDictionary = GetArgumentDictionary(commandLineString, type);
                 operandList = GetOperandList(commandLineString);
             }
 
@@ -509,12 +513,14 @@ namespace Utility.CommandLine
         ///     application was started, keyed by argument name.
         /// </summary>
         /// <param name="commandLineString">The command line arguments with which the application was started.</param>
+        /// <param name="type">The <see cref="Type"/> for which the argument dictionary is to be created.</param>
         /// <returns>
         ///     The dictionary containing the arguments and values specified in the command line arguments with which the
         ///     application was started.
         /// </returns>
-        private static Dictionary<string, object> GetArgumentDictionary(string commandLineString)
+        private static Dictionary<string, object> GetArgumentDictionary(string commandLineString, Type type)
         {
+            List<(string, string)> argumentList = new List<(string, string)>();
             Dictionary<string, object> argumentDictionary = new Dictionary<string, object>();
 
             foreach (Match match in Regex.Matches(commandLineString, ArgumentRegEx))
@@ -532,23 +538,68 @@ namespace Utility.CommandLine
                 value = TrimOuterQuotes(value);
 
                 // check to see if the argument uses a single dash. if so, split the argument name into a char array and add each
-                // to the dictionary. if a value is specified, it belongs to the final character.
+                // to the list. if a value is specified, it belongs to the final character.
                 if (Regex.IsMatch(fullMatch, GroupRegEx))
                 {
                     char[] charArray = argument.ToCharArray();
 
-                    // iterate over the characters backwards to more easily assign the value
+                    // iterate over the characters and assign the value to the final character
                     for (int i = 0; i < charArray.Length; i++)
                     {
-                        argumentDictionary.ExclusiveAdd(charArray[i].ToString(), i == charArray.Length - 1 ? value : string.Empty);
+                        argumentList.Add((charArray[i].ToString(), i == charArray.Length - 1 ? value : string.Empty));
                     }
                 }
                 else
                 {
-                    // add the argument and value to the dictionary if it doesn't already exist.
-                    argumentDictionary.ExclusiveAdd(argument, value);
+                    // add the argument and value to the list.
+                    argumentList.Add((argument, value));
                 }
             }
+
+            // get the short and long names for each argument
+            var nameInfo = GetArgumentInfo(type);
+
+            Dictionary<string, string> shortToLongNames = new Dictionary<string, string>();
+            Dictionary<string, string> longToShortNames = new Dictionary<string, string>();
+
+            foreach (ArgumentInfo info in nameInfo)
+            {
+                shortToLongNames.Add(info.ShortName.ToString(), info.LongName);
+                longToShortNames.Add(info.LongName, info.ShortName.ToString());
+            }
+
+            List<(string, string)> longArgumentList = new List<(string, string)>();
+
+            // populate a new list of argument names,
+            // converting short names to long and filtering out names for which no (short, long) pair exists
+            foreach ((string, string) argument in argumentList)
+            {
+                // convert short names to long
+                if (shortToLongNames.ContainsKey(argument.Item1))
+                {
+                    longArgumentList.Add((shortToLongNames[argument.Item1], argument.Item2));
+                }
+
+                // add long names directly
+                else if (longToShortNames.ContainsKey(argument.Item2))
+                {
+                    longArgumentList.Add(argument);
+                }
+
+                // if this name isn't listed in the argument info, just populate that key in the output dictionary
+                else
+                {
+                    argumentDictionary.ExclusiveAdd(argument.Item1, argument.Item2);
+                }
+            }
+
+            // populate a dictionary with the (key, value) pairs in the list
+            // convert each long name to the corresponding short name and populate that key as well for compatibility
+            longArgumentList.ForEach(argument =>
+            {
+                argumentDictionary.ExclusiveAdd(argument.Item1, argument.Item2);
+                argumentDictionary.ExclusiveAdd(longToShortNames[argument.Item1], argument.Item2);
+            });
 
             return argumentDictionary;
         }

--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -199,10 +199,28 @@ namespace Utility.CommandLine
         /// </summary>
         /// <param name="type">The <see cref="Type"/> for which the matching properties are to be retrieived.</param>
         /// <returns>The retrieved collection of <see cref="ArgumentHelp"/>.</returns>
+        [Obsolete]
         public static IEnumerable<ArgumentHelp> GetArgumentHelp(Type type = null)
         {
             type = type ?? new StackFrame(1).GetMethod().DeclaringType;
-            var retVal = new List<ArgumentHelp>();
+
+            return GetArgumentInfo(type).Select(i => new ArgumentHelp() {
+                ShortName = i.ShortName,
+                LongName = i.LongName,
+                HelpText = i.HelpText,
+            });
+        }
+
+        /// <summary>
+        ///     Retrieves a collection of <see cref="ArgumentInfo"/> gathered from properties in the target <paramref name="type"/>
+        ///     marked with the <see cref="ArgumentAttribute"/><see cref="Attribute"/> along with the short and long names and help text.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> for which the matching properties are to be retrieived.</param>
+        /// <returns>The retrieved collection of <see cref="ArgumentInfo"/>.</returns>
+        public static IEnumerable<ArgumentInfo> GetArgumentInfo(Type type = null)
+        {
+            type = type ?? new StackFrame(1).GetMethod().DeclaringType;
+            var retVal = new List<ArgumentInfo>();
 
             foreach (PropertyInfo property in GetArgumentProperties(type).Values.Distinct())
             {
@@ -210,7 +228,7 @@ namespace Utility.CommandLine
 
                 if (attribute != default(CustomAttributeData))
                 {
-                    retVal.Add(new ArgumentHelp()
+                    retVal.Add(new ArgumentInfo()
                     {
                         ShortName = (char)attribute.ConstructorArguments[0].Value,
                         LongName = (string)attribute.ConstructorArguments[1].Value,

--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -518,6 +518,7 @@ namespace Utility.CommandLine
         ///     The dictionary containing the arguments and values specified in the command line arguments with which the
         ///     application was started.
         /// </returns>
+        [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1009:ClosingParenthesisMustBeFollowedByASpace", Justification = "Conflicts with SA1015.")]
         private static Dictionary<string, object> GetArgumentDictionary(string commandLineString, Type type)
         {
             List<(string, string)> argumentList = new List<(string, string)>();

--- a/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
+++ b/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
@@ -63,10 +63,10 @@ namespace Utility.CommandLine.Tests
     }
 
     /// <summary>
-    ///     Unit tests for the <see cref="CommandLine.ArgumentHelp"/> class.
+    ///     Unit tests for the <see cref="CommandLine.ArgumentInfo"/> class.
     /// </summary>
-    [Collection("ArgumentHelp")]
-    public class ArgumentHelp
+    [Collection("ArgumentInfo")]
+    public class ArgumentInfo
     {
         #region Public Methods
 
@@ -76,7 +76,7 @@ namespace Utility.CommandLine.Tests
         [Fact]
         public void Constructor()
         {
-            CommandLine.ArgumentHelp test = new CommandLine.ArgumentHelp()
+            CommandLine.ArgumentInfo test = new CommandLine.ArgumentInfo()
             {
                 ShortName = 'a',
                 LongName = "aa",
@@ -179,12 +179,12 @@ namespace Utility.CommandLine.Tests
         #region Public Methods
 
         /// <summary>
-        ///     Tests <see cref="CommandLine.Arguments.GetArgumentHelp"/>.
+        ///     Tests <see cref="CommandLine.Arguments.GetArgumentInfo"/>.
         /// </summary>
         [Fact]
-        public void GetArgumentHelp()
+        public void GetArgumentInfo()
         {
-            var help = CommandLine.Arguments.GetArgumentHelp(typeof(Arguments)).ToList();
+            var help = CommandLine.Arguments.GetArgumentInfo(typeof(Arguments)).ToList();
 
             Assert.Equal(7, help.Count);
             Assert.Single(help.Where(h => h.ShortName == 'b'));
@@ -192,12 +192,12 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests <see cref="CommandLine.Arguments.GetArgumentHelp"/> with no arguments.
+        ///     Tests <see cref="CommandLine.Arguments.GetArgumentInfo"/> with no arguments.
         /// </summary>
         [Fact]
-        public void GetArgumentHelpNull()
+        public void GetArgumentInfoNull()
         {
-            var help = CommandLine.Arguments.GetArgumentHelp().ToList();
+            var help = CommandLine.Arguments.GetArgumentInfo().ToList();
 
             Assert.Equal(7, help.Count);
             Assert.Single(help.Where(h => h.ShortName == 'b'));
@@ -217,7 +217,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with the default values.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with the default values.
         /// </summary>
         [Fact]
         public void Parse()
@@ -228,7 +228,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit command line string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with an explicit command line string
         ///     containing a mixture of upper and lower case arguments.
         /// </summary>
         [Fact]
@@ -250,7 +250,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with a string coning a single operand
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with a string coning a single operand
         ///     which contains a dash.
         /// </summary>
         [Fact]
@@ -262,7 +262,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with a decimal value.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with a decimal value.
         /// </summary>
         [Fact]
         public void ParseDecimal()
@@ -273,7 +273,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an empty string.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with an empty string.
         /// </summary>
         [Fact]
         public void ParseEmpty()
@@ -284,7 +284,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit command line string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with an explicit command line string
         ///     containing values with inner quoted strings.
         /// </summary>
         [Fact]
@@ -297,7 +297,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit command line string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with an explicit command line string
         ///     containing a mixture of short and long arguments.
         /// </summary>
         [Fact]
@@ -314,7 +314,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with a mixture of arguments and operands.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with a mixture of arguments and operands.
         /// </summary>
         [Fact]
         public void ParseMixedArgumentsAndOperands()
@@ -327,7 +327,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit command line string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with an explicit command line string
         ///     containing multiple pairs of arguments containing quoted values.
         /// </summary>
         [Fact]
@@ -342,7 +342,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with no argument.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with no argument.
         /// </summary>
         [Fact]
         public void ParseNoArgument()
@@ -353,7 +353,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with a null argument.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with a null argument.
         /// </summary>
         [Fact]
         public void ParseNull()
@@ -364,7 +364,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with a string containing only a series
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with a string containing only a series
         ///     of operands.
         /// </summary>
         [Fact]
@@ -378,7 +378,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with a string containing an operand.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with a string containing an operand.
         /// </summary>
         [Fact]
         public void ParseOperand()
@@ -390,7 +390,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with a string containing multiple operands.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with a string containing multiple operands.
         /// </summary>
         [Fact]
         public void ParseOperands()
@@ -404,7 +404,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit command line string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with an explicit command line string
         ///     containing only short parameters.
         /// </summary>
         [Fact]
@@ -423,7 +423,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with a a string containing only the
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with a a string containing only the
         ///     strict operand delimiter.
         /// </summary>
         [Fact]
@@ -435,7 +435,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with a a string containing multiple
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with a a string containing multiple
         ///     strict operand delimiters.
         /// </summary>
         [Fact]
@@ -451,7 +451,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit operand delimiter.
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with an explicit operand delimiter.
         /// </summary>
         [Fact]
         public void ParseStrictOperands()
@@ -469,7 +469,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit operand delimiter, and
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with an explicit operand delimiter, and
         ///     nothing after the delimiter.
         /// </summary>
         [Fact]
@@ -482,7 +482,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with a a string beginning with the
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with a a string beginning with the
         ///     explicit operand delimiter.
         /// </summary>
         [Fact]
@@ -496,7 +496,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit command line string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with an explicit command line string
         ///     containing only long parameters.
         /// </summary>
         [Fact]
@@ -514,7 +514,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit command line string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with an explicit command line string
         ///     containing a value beginning with a slash.
         /// </summary>
         [Fact]
@@ -526,7 +526,7 @@ namespace Utility.CommandLine.Tests
         }
 
         /// <summary>
-        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string)"/> method with an explicit command line string
+        ///     Tests the <see cref="Utility.CommandLine.Arguments.Parse(string, Type)"/> method with an explicit command line string
         ///     containing arguments with values enclosed in quotes and containing a period.
         /// </summary>
         [Fact]


### PR DESCRIPTION
Renames `GetArgumentHelp` to `GetArgumentInfo` and marks `GetArgumentHelp` as obsolete.
Closes #15.