### PR TITLE
Remove support for argument values beginning with an unquoted forward slash

### DIFF
--- a/build/ci.sh
+++ b/build/ci.sh
@@ -3,7 +3,16 @@ set -e
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 __branch=$(git branch --no-color | grep -E '^\*' | awk '{print $2}')
 
-dotnet-sonarscanner begin /key:"jpdillingham_Utility.CommandLine.Arguments" /o:jpdillingham-github /d:sonar.host.url="https://sonarcloud.io" /d:sonar.exclusions="**/*examples*/**" /d:sonar.branch.name=${__branch} /d:sonar.login="${TOKEN_SONARCLOUD}" /d:sonar.cs.opencover.reportsPaths="tests/opencover.xml"
+export MSYS2_ARG_CONV_EXCL="*"
+
+dotnet-sonarscanner begin \
+	/key:"jpdillingham_Utility.CommandLine.Arguments" \
+	/o:jpdillingham-github \
+	/d:sonar.host.url="https://sonarcloud.io" \
+	/d:sonar.exclusions="**/*examples*/**" \
+	/d:sonar.branch.name=${__branch} \
+	/d:sonar.cs.opencover.reportsPaths="tests/opencover.xml" \
+	/d:sonar.login="${TOKEN_SONARCLOUD}" \
 
 . "${__dir}/build.sh"
 . "${__dir}/test.sh"

--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -474,13 +474,6 @@ namespace Utility.CommandLine
                     }
                     else
                     {
-                        // if the target property Type is an atomic (non-array or list) Type, convert the value and populate it,
-                        // but not if the value is an array or list.
-                        if (valueIsList)
-                        {
-                            throw new InvalidCastException($"Multiple values were specified for argument '{propertyName}', however it is not backed by an array or List<T>.  Specify only one value.");
-                        }
-
                         convertedValue = ChangeType(value, propertyName, propertyType);
                     }
 

--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -176,7 +176,7 @@ namespace Utility.CommandLine
         /// <summary>
         ///     The regular expression with which to parse the command line string.
         /// </summary>
-        private const string ArgumentRegEx = "(?:[-]{1,2}|\\/)([^=: ]+)[=: ]?(\\/?[^-'\"]\\S*|\\\"[^\"]*\\\"|\\\'[^']*\\\')?|([^ ([^'\\\"]+|\"[^\\\"]+\"|\\\'[^']+\\\')";
+        private const string ArgumentRegEx = "(?:[-]{1,2}|\\/)([^=: ]+)[=: ]?([^-'\"\\/]\\S*|\\\"[^\"]*\\\"|\\\'[^']*\\\')?|([^ ([^'\\\"]+|\"[^\\\"]+\"|\\\'[^']+\\\')";
 
         /// <summary>
         ///     The regular expression with which to parse argument-value groups.

--- a/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
+++ b/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
@@ -369,7 +369,7 @@ namespace Utility.CommandLine.Tests
         [Fact]
         public void ParseValueBeginningWithSlash()
         {
-            Dictionary<string, object> test = Arguments.Parse("--file=/mnt/data/test.xml").ArgumentDictionary;
+            Dictionary<string, object> test = Arguments.Parse("--file='/mnt/data/test.xml'").ArgumentDictionary;
 
             Assert.Equal("/mnt/data/test.xml", test["file"]);
         }
@@ -1081,6 +1081,36 @@ namespace Utility.CommandLine.Tests
             Assert.Equal(2, Operands.Count);
             Assert.Equal("operand1", Operands[0]);
             Assert.Equal("operand2", Operands[1]);
+        }
+    }
+
+    [Collection("Arguments")]
+    public class TestWithAllBools
+    {
+        [Argument('a', "aa")]
+        private static bool A { get; set; }
+
+        [Argument('b', "bb")]
+        private static bool B { get; set; }
+
+        [Argument('c', "cc")]
+        private static bool C { get; set; }
+
+        [Theory]
+        [InlineData("-abc")]
+        [InlineData("-a -b -c")]
+        [InlineData("--aa --bb --cc")]
+        [InlineData("/a /b /c")]
+        [InlineData("/aa /bb /cc")]
+        [InlineData("-a --bb /c")]
+        [InlineData("--aa -b /c")]
+        [InlineData("/a /b -c")]
+        [InlineData("-a /bb --cc")]
+        public void PopulateStackedBools(string str)
+        {
+            Arguments.Populate(GetType(), str);
+
+            Assert.True(A && B && C);
         }
     }
 }

--- a/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
+++ b/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
@@ -1113,4 +1113,34 @@ namespace Utility.CommandLine.Tests
             Assert.True(A && B && C);
         }
     }
+
+    [Collection("Arguments")]
+    public class TestListProp
+    {
+        [Argument('a', "aa")]
+        private static string A { get; set; }
+
+        [Argument('b', "bb")]
+        private static List<string> B { get; set; }
+
+        [Fact]
+        public void PopulateSingle()
+        {
+            var ex = Record.Exception(() => Arguments.Populate(GetType(), "--aa one --aa two"));
+
+            Assert.Null(ex);
+            Assert.Equal("two", A);
+        }
+
+        [Fact]
+        public void PopulateList()
+        {
+            var ex = Record.Exception(() => Arguments.Populate(GetType(), "--bb one --bb two"));
+
+            Assert.Null(ex);
+            Assert.Equal(2, B.Count);
+            Assert.Equal("one", B[0]);
+            Assert.Equal("two", B[1]);
+        }
+    }
 }


### PR DESCRIPTION
Somewhat related to #55; this change fixes some erroneous behavior when using multiple arguments with the forward slash delimiter.

`/a /b` should result in two boolean arguments `a` and `b`, but instead would result in one string argument `a` with value `/b`.  This PR corrects this behavior.

This is a breaking change requiring that argument values beginning with a forward slash be quoted (e.g. `/file /input.txt` must now be `/file '/input.txt'`).