### PR TITLE
Disable forward slash as argument delimiter by default

### DIFF
--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -176,7 +176,12 @@ namespace Utility.CommandLine
         /// <summary>
         ///     The regular expression with which to parse the command line string.
         /// </summary>
-        private const string ArgumentRegEx = "(?:[-]{1,2}|\\/)([^=: ]+)[=: ]?([^-'\"\\/]\\S*|\\\"[^\"]*\\\"|\\\'[^']*\\\')?|([^ ([^'\\\"]+|\"[^\\\"]+\"|\\\'[^']+\\\')";
+        private const string ArgumentRegExWithoutForwardSlash = "(?:[-]{1,2})([^=: ]+)[=: ]?([^-'\"]\\S*|\\\"[^\"]*\\\"|\\\'[^']*\\\')?|([^ ([^'\\\"]+|\"[^\\\"]+\"|\\\'[^']+\\\')";
+
+        /// <summary>
+        ///     The regular expression with which to parse the command line string, including the ability to specify forward slashes.
+        /// </summary>
+        private const string ArgumentRegExWithForwardSlash = "(?:[-]{1,2}|\\/)([^=: ]+)[=: ]?([^-'\"\\/]\\S*|\\\"[^\"]*\\\"|\\\'[^']*\\\')?|([^ ([^'\\\"]+|\"[^\\\"]+\"|\\\'[^']+\\\')";
 
         /// <summary>
         ///     The regular expression with which to parse argument-value groups.
@@ -206,6 +211,11 @@ namespace Utility.CommandLine
             OperandList = operandList;
             TargetType = targetType;
         }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether forward slashes are processed as argument delimiters.
+        /// </summary>
+        public static bool EnableForwardSlash { get; set; } = false;
 
         /// <summary>
         ///     Gets a dictionary containing the arguments and values specified in the command line arguments with which the
@@ -241,6 +251,8 @@ namespace Utility.CommandLine
         ///     Gets the target Type, if applicable.
         /// </summary>
         public Type TargetType { get; }
+
+        private static string ArgumentRegEx => EnableForwardSlash ? ArgumentRegExWithForwardSlash : ArgumentRegExWithoutForwardSlash;
 
         /// <summary>
         ///     Gets the argument value corresponding to the specified <paramref name="index"/>.

--- a/src/Utility.CommandLine.Arguments/Utility.CommandLine.Arguments.csproj
+++ b/src/Utility.CommandLine.Arguments/Utility.CommandLine.Arguments.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.0.0</Version>
+    <Version>5.0.0</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Utility.CommandLine.Arguments</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Utility.CommandLine.Arguments</PackageProjectUrl>

--- a/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
+++ b/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
@@ -197,7 +197,7 @@ namespace Utility.CommandLine.Tests
         [Fact]
         public void ParseLongAndShortMix()
         {
-            Dictionary<string, object> test = Arguments.Parse("--one=1 -ab 2 /three:3 -4 4").ArgumentDictionary;
+            Dictionary<string, object> test = Arguments.Parse("--one=1 -ab 2 --three:3 -4 4").ArgumentDictionary;
 
             Assert.Equal("1", test["one"]);
             Assert.True(test.ContainsKey("a"));
@@ -355,7 +355,7 @@ namespace Utility.CommandLine.Tests
         [Fact]
         public void ParseStringOfLongs()
         {
-            Dictionary<string, object> test = Arguments.Parse("--one 1 --two=2 /three:3 --four \"4 4\" --five='5 5'").ArgumentDictionary;
+            Dictionary<string, object> test = Arguments.Parse("--one 1 --two=2 --three:3 --four \"4 4\" --five='5 5'").ArgumentDictionary;
 
             Assert.NotEmpty(test);
             Assert.Equal(5, test.Count);
@@ -395,6 +395,15 @@ namespace Utility.CommandLine.Tests
         [InlineData("\\foo\\bar")]
         [InlineData("\\\\foo")]
         [InlineData("\\\\foo\\bar")]
+        [InlineData("..//")]
+        [InlineData(".//foo")]
+        [InlineData("..//foo")]
+        [InlineData("..//..")]
+        [InlineData("//")]
+        [InlineData("//foo")]
+        [InlineData("//foo//bar")]
+        [InlineData("////foo")]
+        [InlineData("////foo//bar")]
         public void ParseValueStartingWithNonWord(string value)
         {
             Dictionary<string, object> test = Arguments.Parse($"-f {value}").ArgumentDictionary;
@@ -1100,12 +1109,11 @@ namespace Utility.CommandLine.Tests
         [InlineData("-abc")]
         [InlineData("-a -b -c")]
         [InlineData("--aa --bb --cc")]
-        [InlineData("/a /b /c")]
-        [InlineData("/aa /bb /cc")]
-        [InlineData("-a --bb /c")]
-        [InlineData("--aa -b /c")]
-        [InlineData("/a /b -c")]
-        [InlineData("-a /bb --cc")]
+        [InlineData("-a -b -c")]
+        [InlineData("--aa --bb --cc")]
+        [InlineData("-a --bb -c")]
+        [InlineData("--aa -b -c")]
+        [InlineData("-a --bb --cc")]
         public void PopulateStackedBools(string str)
         {
             Arguments.Populate(GetType(), str);


### PR DESCRIPTION
Closes #61 

The removal is a breaking change from 4.0; impacted projects should set `Arguments.EnableForwardSlash = true` prior to invoking `Populate()` or `Parse()` in order to retain the previous behavior.