### PR TITLE
Add ArgumentParseOptions and overloads for Parse() accepting them

### DIFF
--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
   █▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀ ▀▀▀  ▀  ▀      ▀▀
   █  The MIT License (MIT)
   █
@@ -165,6 +165,36 @@ namespace Utility.CommandLine
         ///     Gets the short name of the argument.
         /// </summary>
         public char ShortName { get; }
+    }
+
+    /// <summary>
+    ///     Parsing options.
+    /// </summary>
+    public class ArgumentParseOptions
+    {
+        /// <summary>
+        ///     Gets or sets the <see cref="Type"/> for which the command line string is to be parsed.
+        /// </summary>
+        /// <remarks>
+        ///     Supersedes combination options; arguments backed by properties of a collection type are combined, while those that aren't are not.
+        /// </remarks>
+        public Type TargetType { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether duplicate argument values should be combined into a list.
+        /// </summary>
+        /// <remarks>
+        ///     Only applicable if <see cref="TargetType"/> is not specified.
+        /// </remarks>
+        public bool CombineAllMultiples { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether duplicate argument values for arguments in the array should be combined into a list.
+        /// </summary>
+        /// <remarks>
+        ///     Only applicable if <see cref="TargetType"/> is not specified.
+        /// </remarks>
+        public string[] CombinableArguments { get; set; } = Array.Empty<string>();
     }
 
     /// <summary>

--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -321,7 +321,7 @@ namespace Utility.CommandLine
         ///     The dictionary containing the arguments and values specified in the command line arguments with which the
         ///     application was started.
         /// </returns>
-        public static Arguments Parse(string commandLineString = default(string), Type type = null, [CallerMemberName] string caller = default(string))
+        public static Arguments Parse(string commandLineString = default(string), Type type = null, bool appendRepeatedValuesForUnmatchedArguments = false, [CallerMemberName] string caller = default(string))
         {
             commandLineString = commandLineString == default(string) || string.IsNullOrEmpty(commandLineString) ? Environment.CommandLine : commandLineString;
 
@@ -353,7 +353,7 @@ namespace Utility.CommandLine
                 operandList = GetOperandList(commandLineString);
             }
 
-            var argumentDictionary = GetArgumentDictionary(argumentList, type);
+            var argumentDictionary = GetArgumentDictionary(argumentList, type, appendRepeatedValuesForUnmatchedArguments);
             return new Arguments(commandLineString, argumentList, argumentDictionary, operandList, type);
         }
 
@@ -537,7 +537,7 @@ namespace Utility.CommandLine
             }
         }
 
-        private static Dictionary<string, object> GetArgumentDictionary(List<KeyValuePair<string, string>> argumentList, Type targetType = null)
+        private static Dictionary<string, object> GetArgumentDictionary(List<KeyValuePair<string, string>> argumentList, Type targetType = null, bool appendRepeatedValuesForUnmatchedArguments = false)
         {
             var dict = new ConcurrentDictionary<string, object>();
             var argumentInfo = targetType == null ? new List<ArgumentInfo>() : GetArgumentInfo(targetType);
@@ -567,7 +567,15 @@ namespace Utility.CommandLine
                 }
                 else
                 {
-                    dict.AddOrUpdate(arg.Key, arg.Value, (key, existingValue) => arg.Value);
+                    if (!appendRepeatedValuesForUnmatchedArguments)
+                    {
+                        dict.AddOrUpdate(arg.Key, arg.Value, (key, existingValue) => arg.Value);
+                    }
+                    else
+                    {
+                        // todo: check if key exists.  if so, check if value is a List.  if so, append this value to the existing list
+                        // if existing value is not a List, convert it to a list containing the existing value, and this value.
+                    }
                 }
             }
 

--- a/src/Utility.CommandLine.Arguments/Arguments.cs
+++ b/src/Utility.CommandLine.Arguments/Arguments.cs
@@ -344,15 +344,49 @@ namespace Utility.CommandLine
         ///     Returns a dictionary containing the values specified in the command line arguments with which the application was
         ///     started, keyed by argument name.
         /// </summary>
-        /// <param name="commandLineString">The command line arguments with which the application was started.</param>
-        /// <param name="type">The <see cref="Type"/> for which the command line string is to be parsed.</param>
-        /// <param name="caller">Internal parameter used to identify the calling method.</param>
+        /// <param name="configure">An action to configure the provided <see cref="ArgumentParseOptions"/> instance.</param>
         /// <returns>
         ///     The dictionary containing the arguments and values specified in the command line arguments with which the
         ///     application was started.
         /// </returns>
-        public static Arguments Parse(string commandLineString = default(string), Type type = null, bool appendRepeatedValuesForUnmatchedArguments = false, [CallerMemberName] string caller = default(string))
+        public static Arguments Parse(Action<ArgumentParseOptions> configure = null)
         {
+            return Parse(null, configure);
+        }
+
+        /// <summary>
+        ///     Returns a dictionary containing the values specified in the command line arguments with which the application was
+        ///     started, keyed by argument name.
+        /// </summary>
+        /// <param name="commandLineString">The command line arguments with which the application was started.</param>
+        /// <param name="configure">An action to configure the provided <see cref="ArgumentParseOptions"/> instance.</param>
+        /// <returns>
+        ///     The dictionary containing the arguments and values specified in the command line arguments with which the
+        ///     application was started.
+        /// </returns>
+        public static Arguments Parse(string commandLineString, Action<ArgumentParseOptions> configure = null)
+        {
+            configure = configure ?? new Action<ArgumentParseOptions>((_) => { });
+            var options = new ArgumentParseOptions();
+            configure(options);
+            
+            return Parse(commandLineString, options);
+        }
+
+        /// <summary>
+        ///     Returns a dictionary containing the values specified in the command line arguments with which the application was
+        ///     started, keyed by argument name.
+        /// </summary>
+        /// <param name="commandLineString">The command line arguments with which the application was started.</param>
+        /// <param name="options">Parser options.</param>
+        /// <returns>
+        ///     The dictionary containing the arguments and values specified in the command line arguments with which the
+        ///     application was started.
+        /// </returns>
+        public static Arguments Parse(string commandLineString, ArgumentParseOptions options)
+        {
+            options = options ?? new ArgumentParseOptions();
+
             commandLineString = commandLineString == default(string) || string.IsNullOrEmpty(commandLineString) ? Environment.CommandLine : commandLineString;
 
             List<KeyValuePair<string, string>> argumentList;

--- a/src/Utility.CommandLine.Arguments/Utility.CommandLine.Arguments.csproj
+++ b/src/Utility.CommandLine.Arguments/Utility.CommandLine.Arguments.csproj
@@ -11,7 +11,7 @@
 
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>5.0.0</Version>
+    <Version>6.0.0</Version>
     <Authors>JP Dillingham</Authors>
     <Product>Utility.CommandLine.Arguments</Product>
     <PackageProjectUrl>https://github.com/jpdillingham/Utility.CommandLine.Arguments</PackageProjectUrl>

--- a/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
+++ b/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
@@ -367,6 +367,16 @@ namespace Utility.CommandLine.Tests
         }
 
         [Fact]
+        public void ParseMultiples()
+        {
+            Dictionary<string, object> test = Arguments.Parse("--test 1 --test 2").ArgumentDictionary;
+
+            Assert.NotEmpty(test);
+            Assert.Single(test);
+            Assert.Equal("1,2", test["test"]);
+        }
+
+        [Fact]
         public void ParseValueBeginningWithSlash()
         {
             Dictionary<string, object> test = Arguments.Parse("--file='/mnt/data/test.xml'").ArgumentDictionary;

--- a/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
+++ b/tests/Utility.CommandLine.Arguments.Tests/ArgumentsTests.cs
@@ -367,13 +367,45 @@ namespace Utility.CommandLine.Tests
         }
 
         [Fact]
-        public void ParseMultiples()
+        public void ParseMultiples_No_CombineAllMultiples()
         {
-            Dictionary<string, object> test = Arguments.Parse("--test 1 --test 2").ArgumentDictionary;
+            Dictionary<string, object> test = Arguments.Parse("--test 1 --test 2", options => options.CombineAllMultiples = false).ArgumentDictionary;
 
             Assert.NotEmpty(test);
             Assert.Single(test);
-            Assert.Equal("1,2", test["test"]);
+            Assert.Equal("2", test["test"]);
+        }
+
+        [Fact]
+        public void ParseMultiples_With_CombineAllMultiples()
+        {
+            Dictionary<string, object> test = Arguments.Parse("--test 1 --test 2", options => options.CombineAllMultiples = true).ArgumentDictionary;
+
+            Assert.NotEmpty(test);
+            Assert.Single(test);
+
+            var values = (List<object>)test["test"];
+
+            Assert.Equal(2, values.Count);
+            Assert.Equal("1", values[0]);
+            Assert.Equal("2", values[1]);
+        }
+
+        [Fact]
+        public void ParseMultiples_With_Specific_CombinableArguments()
+        {
+            Dictionary<string, object> test = Arguments.Parse("--test 1 --test 2 --foo foo --foo bar", options => options.CombinableArguments = new[] { "test" }).ArgumentDictionary;
+
+            Assert.NotEmpty(test);
+            Assert.Equal(2, test.Count);
+
+            var values = (List<object>)test["test"];
+
+            Assert.Equal(2, values.Count);
+            Assert.Equal("1", values[0]);
+            Assert.Equal("2", values[1]);
+
+            Assert.Equal("bar", test["foo"]);
         }
 
         [Fact]
@@ -800,7 +832,7 @@ namespace Utility.CommandLine.Tests
                 new KeyValuePair<string, string>("l", "bar")
             };
 
-            var a = Arguments.Parse("-l foo -l bar", GetType());
+            var a = Arguments.Parse("-l foo -l bar", options => options.TargetType = GetType());
             var dict = a.ArgumentDictionary;
 
             List<object> argList = null;
@@ -823,7 +855,7 @@ namespace Utility.CommandLine.Tests
                 new KeyValuePair<string, string>("list", "bar")
             };
 
-            var a = Arguments.Parse("--list foo --list bar", GetType());
+            var a = Arguments.Parse("--list foo --list bar", options => options.TargetType = GetType());
             var dict = a.ArgumentDictionary;
 
             List<object> argList = null;
@@ -846,7 +878,7 @@ namespace Utility.CommandLine.Tests
                 new KeyValuePair<string, string>("list", "bar")
             };
 
-            var a = Arguments.Parse("-l foo --list bar", GetType());
+            var a = Arguments.Parse("-l foo --list bar", options => options.TargetType = GetType());
             var dict = a.ArgumentDictionary;
 
             List<object> argList = null;
@@ -869,7 +901,7 @@ namespace Utility.CommandLine.Tests
                 new KeyValuePair<string, string>("l", "bar")
             };
 
-            var a = Arguments.Parse("--list foo -l bar", GetType());
+            var a = Arguments.Parse("--list foo -l bar", options => options.TargetType = GetType());
             var dict = a.ArgumentDictionary;
 
             List<object> argList = null;
@@ -911,7 +943,7 @@ namespace Utility.CommandLine.Tests
                 new KeyValuePair<string, string>("b", "2")
             };
 
-            var a = Arguments.Parse("-b 1 -b 2", GetType());
+            var a = Arguments.Parse("-b 1 -b 2", options => options.TargetType = GetType());
             var dict = a.ArgumentDictionary;
 
             Assert.Single(dict);
@@ -928,7 +960,7 @@ namespace Utility.CommandLine.Tests
                 new KeyValuePair<string, string>("bb", "2")
             };
 
-            var a = Arguments.Parse("--bb 1 --bb 2", GetType());
+            var a = Arguments.Parse("--bb 1 --bb 2", options => options.TargetType = GetType());
             var dict = a.ArgumentDictionary;
 
             Assert.Single(dict);
@@ -996,7 +1028,7 @@ namespace Utility.CommandLine.Tests
                 new KeyValuePair<string, string>("bb", "2")
             };
 
-            var a = Arguments.Parse("--bb 1 --bb 2", GetType());
+            var a = Arguments.Parse("--bb 1 --bb 2", options => options.TargetType = GetType());
 
             Assert.NotNull(a.TargetType);
             Assert.Equal(GetType(), a.TargetType);
@@ -1025,7 +1057,7 @@ namespace Utility.CommandLine.Tests
                 new KeyValuePair<string, string>("b", "2")
             };
 
-            var a = Arguments.Parse("--bb 1 -b 2", GetType());
+            var a = Arguments.Parse("--bb 1 -b 2", options => options.TargetType = GetType());
             var dict = a.ArgumentDictionary;
 
             Assert.Single(dict);
@@ -1042,7 +1074,7 @@ namespace Utility.CommandLine.Tests
                 new KeyValuePair<string, string>("bb", "2")
             };
 
-            var a = Arguments.Parse("-b 1 --bb 2", GetType());
+            var a = Arguments.Parse("-b 1 --bb 2", options => options.TargetType = GetType());
             var dict = a.ArgumentDictionary;
 
             Assert.Single(dict);


### PR DESCRIPTION
Initially just three options;

* `TargetType` -- same functionality as the previous targetType parameter
* `CombineAllMultiples` -- combines repeated argument values into a list 
* `CombinableArguments` -- if `CombineAllMultiples` is `false`, combines the specified arguments into a list

If `TargetType` is supplied and repeated arguments match a property in the type, the behavior remains the same; if the backing type of the property is a collection, values are combined, otherwise they are overwritten.

If `TargetType` is not supplied, or repeated arguments don't match a property in the type, the behavior depends on the other options for multiples, either everything or just those specified.

Closes #66 